### PR TITLE
Rework bad architecture logic

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -30,7 +30,9 @@ get_platform() {
 }
 
 get_arch() {
-  [ "x86_64" = "$(uname -m)" ] && echo "x86_64" || echo "i386"
+  # the ctlptl builds map exactly to the names of the architectures
+  # returned by uname -m.
+  uname -m
 }
 
 get_download_url() {


### PR DESCRIPTION
The Architecture logic in the get arch function was masking the arm64
architecture and also outputting i386 when that isn't even a available
architecture option for ctlptl builds. Removing the logic and just
replacing it with a call to uname -m. This enables ctlptl to be installed on 
M1 Macs.