### PR TITLE
docs: update documentation to be compatible with asdf 0.16+

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Install
 
 ```
-asdf plugin-add ctlptl https://github.com/ezcater/asdf-ctlptl.git
+asdf plugin add ctlptl https://github.com/ezcater/asdf-ctlptl.git
 ```
 
 ## Use


### PR DESCRIPTION
In asdf v0.16, `asdf plugin-add` [has been removed].

[has been removed]: https://asdf-vm.com/guide/upgrading-to-v0-16.html#hyphenated-commands-have-been-removed